### PR TITLE
Additional Skelestruder support for Mk3

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -3184,7 +3184,11 @@ void gcode_M701()
 		st_synchronize();
 
 		marlin_rise_z();
+#ifdef SKELESTRUDER
+		current_position[E_AXIS] += 20;
+#else
 		current_position[E_AXIS] += 30;
+#endif
 		plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 400 / 60, active_extruder); //fast sequence
 		
 		load_filament_final_feed(); //slow sequence

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -6012,10 +6012,19 @@ void unload_filament()
 	lcd_setstatuspgm(_T(MSG_UNLOADING_FILAMENT));
 
 	//		extr_unload2();
-
+#ifdef SKELESTRUDER
+	current_position[E_AXIS] += 5;
+	plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 500 / 60, active_extruder);
+	st_synchronize();
+#endif
 	current_position[E_AXIS] -= 45;
 	plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 5200 / 60, active_extruder);
 	st_synchronize();
+#ifdef SKELESTRUDER
+	current_position[E_AXIS] += 10;
+	plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 500 / 60, active_extruder);
+	st_synchronize();
+#endif
 	current_position[E_AXIS] -= 15;
 	plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 1000 / 60, active_extruder);
 	st_synchronize();

--- a/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK3-EINSy10a-E3Dv6full.h
@@ -80,6 +80,7 @@
 //Don't forget to also send gcode to set e-steps as detailed earlier
 //Reversion back from geared extruder requires sending M92 E280 & M500 to printer
 //
+//#define SKELESTRUDER // Uncomment if you have a skelestruder. Applies the patches for load distances and Z height.
 //#define BMG_EXTRUDER //Kuo Uncomment for BMG 3:1 extruder. This also sets BMG height for you.
 //#define EXTRUDER_GEARRATIO_30 //Kuo Uncomment for extruder with gear ratio 3.0. 
 //#define EXTRUDER_GEARRATIO_3375 //Kuo Uncomment for extruder with gear ratio 3.375 like 54:16 BNBSX.
@@ -90,6 +91,10 @@
 //#define DEFAULT_AXIS_STEPS_PER_UNIT   {100,100,3200/8,140}
 //#define DEFAULT_AXIS_STEPS_PER_UNIT   {100,100,3200/8,280}
 //#define DEFAULT_AXIS_STEPS_PER_UNIT   {100,100,3200/8,560}
+
+#ifdef SKELESTRUDER
+  #define EXTRUDER_GEARRATIO_35
+#endif
 
 #ifndef EXTRUDER_GEARED //Kuo for e-axis msteps
 #ifdef BMG_EXTRUDER 
@@ -155,6 +160,8 @@
 #define Y_MIN_POS -4 //orig -4
 #ifdef BMG_EXTRUDER
   #define Z_MAX_POS 205 //kuo BMG height
+#elifdef SKELESTRUDER
+  #define Z_MAX_POS 220 //Skelestruder height
 #else
   #define Z_MAX_POS 210 //default height
 #endif


### PR DESCRIPTION
Added Max Z and load/unload changes from the Skelestruder diff posted here:

https://jltxplore.dozuki.com/Wiki/Skelestruder_Information

These are controlled by a new #define SKELESTRUDER (which also sets the gear ratio to 3.5)