### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,12 @@ Wiring is as in pictures. Pay attention to wire order and pin positions at both 
 NB: if using retrograde motor extruder like BNBSX Short Ears, plug EINSY end in 180 degrees rotated
 NB2: LDO's use different pinout not detailed here.
 
+[DIY Stepper Cables: RGB LED Strjp Cables](https://www.amazon.com/gp/product/B01DC0KKJU/) 	$9
+BTF-LIGHTING 10 Pairs 4pin SM JST 15cm Cable Female/Male connectors for Led Strip RGB 5050 3528 WS2801 APA02
+
+If you want pre-assembled connector and wire assemblies, while not specifically intended for stepper motors, these RGB LED strip connectors are a great alternative.  They have color-coded wires that match the standard stepper motor wire colors, they are meant to handle a couple of amps or more.  These are great for steppers that have wires already attached.
+
+
 ![EINSY end of cable](https://github.com/guykuo/Prusa-Firmware/blob/0.9-Degree-Stepper-Support/einsy-end-of-cable.jpg)
 
 ![Moons motor connector wire order detail](https://github.com/guykuo/Prusa-Firmware/blob/0.9-Degree-Stepper-Support/moons-end-of-cable.jpg)


### PR DESCRIPTION
I've been using these RGD LED connectors for quickly connecting and disconnecting steppers, and they work great.  They make a very secure connection and are very easy to solder - you just splice the like wire colors to the connector, and it has 10 pairs of mating male/female assemblies.  

I thought I might propose it as a good way to add connectors to steppers that have their own wires vs. the little JST connectors, but of course don't accept this PR if you have any issue with it.  Just wanted to share a tip :)

